### PR TITLE
Move common structs and defines to public headers

### DIFF
--- a/include/swx/channel.h
+++ b/include/swx/channel.h
@@ -15,10 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef _STATUS_H
-#define _STATUS_H
+#ifndef _CHANNEL_H
+#define _CHANNEL_H
 
 #include <inttypes.h>
+
+#define TOTAL_ANALOG_CHANNELS (3)
 
 typedef enum {
    CHANNEL_INVALID = 0,
@@ -28,4 +30,12 @@ typedef enum {
    CHANNEL_READY,
 } channel_status_t;
 
-#endif // _STATUS_H
+typedef enum {
+   AUDIO_CHANNEL_NONE = 0,
+
+   AUDIO_CHANNEL_MIC,
+   AUDIO_CHANNEL_LEFT,
+   AUDIO_CHANNEL_RIGHT,
+} analog_channel_t;
+
+#endif // _CHANNEL_H

--- a/include/swx/message.h
+++ b/include/swx/message.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _MESSAGE_H
 #define _MESSAGE_H
 

--- a/include/swx/parameter.h
+++ b/include/swx/parameter.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _PARAMETER_H
 #define _PARAMETER_H
 

--- a/include/swx/status.h
+++ b/include/swx/status.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _STATUS_H
 #define _STATUS_H
 

--- a/include/swx/version.h
+++ b/include/swx/version.h
@@ -1,0 +1,23 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _SWX_VERSION_H
+#define _SWX_VERSION_H
+
+#define SWX_VERSION (1100)
+
+#endif // _SWX_VERSION_H

--- a/src/analog_capture.c
+++ b/src/analog_capture.c
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "analog_capture.h"
 
 #include <pico/stdlib.h>

--- a/src/analog_capture.h
+++ b/src/analog_capture.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _ANALOG_CAPTURE_H
 #define _ANALOG_CAPTURE_H
 

--- a/src/analog_capture.h
+++ b/src/analog_capture.h
@@ -20,15 +20,7 @@
 
 #include "swx.h"
 
-#define TOTAL_ANALOG_CHANNELS (3)
-
-typedef enum {
-   AUDIO_CHANNEL_NONE = 0,
-
-   AUDIO_CHANNEL_MIC,
-   AUDIO_CHANNEL_LEFT,
-   AUDIO_CHANNEL_RIGHT,
-} analog_channel_t;
+#include "channel.h"
 
 void analog_capture_init();
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1,3 +1,24 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Based on https://github.com/CrashOverride85/zc95/blob/c67a58668be187b63eeebab66ec8583b33494d43/source/zc95/AudioInput/CAudio3Process.cpp
+ * Changes: Add support for swx channel parameter system. Allow adjustment of the pulse width, maximum power, and frequency.
+ */
 #include "swx.h"
 #include <stdlib.h>
 

--- a/src/hardware/ads1015.c
+++ b/src/hardware/ads1015.c
@@ -116,6 +116,7 @@ static uint16_t read_register(uint8_t reg) {
 
 void init_adc() {}
 
+// Based on https://github.com/adafruit/Adafruit_ADS1X15/blob/7026e332655fbf9cb1b9523748d78324ffafd11e/Adafruit_ADS1X15.cpp
 bool adc_read_counts(uint8_t channel, uint16_t* counts) {
    if (channel >= ADS1015_CHANNEL_COUNT) {
       LOG_WARN("ADS1015: ch=%u - Out of range channel index!\n", channel);

--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "swx.h"
 
 #include <pico/multicore.h>

--- a/src/output.c
+++ b/src/output.c
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "output.h"
 
 #include <pico/util/queue.h>

--- a/src/output.c
+++ b/src/output.c
@@ -22,7 +22,7 @@
 #include "util/i2c.h"
 #include "util/gpio.h"
 
-#include "status.h"
+#include "channel.h"
 #include "state.h"
 
 #include "pulse_gen.pio.h"

--- a/src/output.h
+++ b/src/output.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _OUTPUT_H
 #define _OUTPUT_H
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "protocol.h"
 #include "state.h"
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _PROTOCOL_H
 #define _PROTOCOL_H
 

--- a/src/pulse_gen.c
+++ b/src/pulse_gen.c
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "pulse_gen.h"
 #include "output.h"
 #include "parameter.h"

--- a/src/pulse_gen.h
+++ b/src/pulse_gen.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _PULSE_GEN_H
 #define _PULSE_GEN_H
 

--- a/src/state.h
+++ b/src/state.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _STATE_H
 #define _STATE_H
 

--- a/src/swx.h
+++ b/src/swx.h
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#define SWX_VERSION (1100)
+#include "version.h"
 
 #if !defined(PIN_LED) && defined(PICO_DEFAULT_LED_PIN)
 #define PIN_LED (PICO_DEFAULT_LED_PIN)

--- a/src/swx.h
+++ b/src/swx.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _SWX_H
 #define _SWX_H
 

--- a/src/util/gpio.h
+++ b/src/util/gpio.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _GPIO_H
 #define _GPIO_H
 

--- a/src/util/i2c.c
+++ b/src/util/i2c.c
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #include "i2c.h"
 
 #include <pico/mutex.h>

--- a/src/util/i2c.h
+++ b/src/util/i2c.h
@@ -1,3 +1,20 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef _I2C_H
 #define _I2C_H
 


### PR DESCRIPTION
Renamed public header `status.h` to `channel.h`
Moved to public headers:
- `analog_channel_t`
- `SWX_VERSION`
