### PR TITLE
Routineless control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ else() # configure as swx driver firmware using pico-sdk
             "src/protocol.c"
             "src/audio.c"
             "src/analog_capture.c"
+            "src/trigger.c"
             "src/util/i2c.c"        
             "src/hardware/mcp4728.c"
             "src/hardware/ads1015.c"

--- a/boards/SW22.h
+++ b/boards/SW22.h
@@ -20,6 +20,13 @@
 #define PIN_I2S_WS (21)
 #define PIN_I2S_SD (22)
 
+// Triggers are unavailable for the SW22 board
+#define TRIGGER_COUNT (0)
+//#define PIN_TRIGGER1 (14)
+//#define PIN_TRIGGER2 (15)
+//#define PIN_TRIGGER3 (16)
+//#define PIN_TRIGGER4 (17)
+
 // -------- I2C --------
 
 // Port used for communications with controller (I2C slave mode).

--- a/include/swx/message.h
+++ b/include/swx/message.h
@@ -19,7 +19,7 @@
 #define _MESSAGE_H
 
 #define READ_ONLY_ADDRESS_BOUNDARY (0x20)
-#define MAX_STATE_MEM_SIZE (0x450)
+#define MAX_STATE_MEM_SIZE (0x800)
 
 #define REG_VERSION (0)                 // bytes 0 & 1 (readonly)
 #define REG_VERSION_L (REG_VERSION)     // (readonly)
@@ -100,6 +100,13 @@
 #define REG_SEQ_COUNT (93) // sequence item count (uint8_t)
 #define REG_SEQn (94)      // max MAX_SEQ_COUNT
 
-#define REG_CHnn_PARAM (224) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
+#define MAX_ACTIONS (255) // Max supported action count is 255 since action value (uint16) must be able to fit start/end indices
+
+#define REG_An_TYPE (224)         // action_type_t (uint8_t)
+#define REG_An_CHANNEL_MASK (479) // action channel mask (uint8_t)
+#define REG_An_PARAM_TARGET (734) // action parameter+target (uint8_t) upper nibble is parameter, lower nibble is target
+#define REG_Ann_VALUE (989)       // action value (uint16_t)
+
+#define REG_CHnn_PARAM (1500) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
 
 #endif // _MESSAGE_H

--- a/include/swx/message.h
+++ b/include/swx/message.h
@@ -21,9 +21,7 @@
 #define READ_ONLY_ADDRESS_BOUNDARY (0x20)
 #define MAX_STATE_MEM_SIZE (0x900)
 
-#define REG_VERSION (0)                 // bytes 0 & 1 (readonly)
-#define REG_VERSION_L (REG_VERSION)     // (readonly)
-#define REG_VERSION_H (REG_VERSION + 1) // (readonly)
+#define REG_VERSION_w (0)
 
 #define REG_CHANNEL_COUNT (2)  // Number of channels (readonly)
 #define REG_CH_CAL_ENABLED (3) // (readonly)
@@ -34,11 +32,11 @@
 #define REG_CH3_STATUS (REG_CHn_STATUS + 2)
 #define REG_CH4_STATUS (REG_CHn_STATUS + 3)
 
-#define REG_CHnn_CAL_VALUE (9) // uint16_t channel cal value (readonly)
-#define REG_CH1_CAL_VALUE (REG_CHnn_CAL_VALUE + 0)
-#define REG_CH2_CAL_VALUE (REG_CHnn_CAL_VALUE + 2)
-#define REG_CH3_CAL_VALUE (REG_CHnn_CAL_VALUE + 4)
-#define REG_CH4_CAL_VALUE (REG_CHnn_CAL_VALUE + 6)
+#define REG_CHn_CAL_VALUE_w (9) // uint16_t channel cal value (readonly)
+#define REG_CH1_CAL_VALUE_w (REG_CHn_CAL_VALUE_w + 0)
+#define REG_CH2_CAL_VALUE_w (REG_CHn_CAL_VALUE_w + 2)
+#define REG_CH3_CAL_VALUE_w (REG_CHn_CAL_VALUE_w + 4)
+#define REG_CH4_CAL_VALUE_w (REG_CHn_CAL_VALUE_w + 6)
 
 // -----------------------------------------------------
 
@@ -54,18 +52,18 @@
 #define REG_CH4_GEN_ENABLE_BIT (3)
 #define REG_CH4_GEN_ENABLE_MASK (1 << REG_CH4_GEN_ENABLE_BIT)
 
-#define REG_CHnn_POWER (34) // uint16_t channel power level (scaled with PARAM_POWER)
-#define REG_CH1_POWER (REG_CHnn_POWER + 0)
-#define REG_CH2_POWER (REG_CHnn_POWER + 2)
-#define REG_CH3_POWER (REG_CHnn_POWER + 4)
-#define REG_CH4_POWER (REG_CHnn_POWER + 6)
+#define REG_CHn_POWER_w (34) // uint16_t channel power level (scaled with PARAM_POWER)
+#define REG_CH1_POWER_w (REG_CHn_POWER_w + 0)
+#define REG_CH2_POWER_w (REG_CHn_POWER_w + 2)
+#define REG_CH3_POWER_w (REG_CHn_POWER_w + 4)
+#define REG_CH4_POWER_w (REG_CHn_POWER_w + 6)
 
 // Status flags for when the param value has reached an extent (min/max). Flag bits should be reset when acknowledged.
-#define REG_CHnn_PARAM_FLAGS (50)
-#define REG_CH1_PARAM_FLAGS (REG_CHnn_PARAM_FLAGS + 0)
-#define REG_CH2_PARAM_FLAGS (REG_CHnn_PARAM_FLAGS + 2)
-#define REG_CH3_PARAM_FLAGS (REG_CHnn_PARAM_FLAGS + 4)
-#define REG_CH4_PARAM_FLAGS (REG_CHnn_PARAM_FLAGS + 6)
+#define REG_CHn_PARAM_FLAGS_w (50)
+#define REG_CH1_PARAM_FLAGS_w (REG_CHn_PARAM_FLAGS_w + 0)
+#define REG_CH2_PARAM_FLAGS_w (REG_CHn_PARAM_FLAGS_w + 2)
+#define REG_CH3_PARAM_FLAGS_w (REG_CHn_PARAM_FLAGS_w + 4)
+#define REG_CH4_PARAM_FLAGS_w (REG_CHn_PARAM_FLAGS_w + 6)
 
 #define REG_CHn_AUDIO_SRC (66) // Channel audio source, override default pulse_gen. see analog_channel_t
 #define REG_CH1_AUDIO_SRC (REG_CHn_AUDIO_SRC + 0)

--- a/include/swx/message.h
+++ b/include/swx/message.h
@@ -19,7 +19,7 @@
 #define _MESSAGE_H
 
 #define READ_ONLY_ADDRESS_BOUNDARY (0x20)
-#define MAX_STATE_MEM_SIZE (0x800)
+#define MAX_STATE_MEM_SIZE (0x900)
 
 #define REG_VERSION (0)                 // bytes 0 & 1 (readonly)
 #define REG_VERSION_L (REG_VERSION)     // (readonly)
@@ -101,12 +101,15 @@
 #define REG_SEQn (94)      // max MAX_SEQ_COUNT
 
 #define MAX_ACTIONS (255) // Max supported action count is 255 since action value (uint16) must be able to fit start/end indices
+#define ACTION_SIZE (5)   // size of action entry in bytes
 
+// Action entries are stored sequentially and can be accessed using ACTION_SIZE * index + REG_An_...
 #define REG_An_TYPE (224)         // action_type_t (uint8_t)
-#define REG_An_CHANNEL_MASK (479) // action channel mask (uint8_t)
-#define REG_An_PARAM_TARGET (734) // action parameter+target (uint8_t) upper nibble is parameter, lower nibble is target
-#define REG_Ann_VALUE (989)       // action value (uint16_t)
+#define REG_An_CHANNEL_MASK (225) // action channel mask (uint8_t)
+#define REG_An_PARAM_TARGET (226) // action parameter+target (uint8_t) upper nibble is parameter, lower nibble is target
+#define REG_An_VALUE_w (227)      // action value (uint16_t)
 
-#define REG_CHnn_PARAM (1500) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
+
+#define REG_CHn_PARAM_w (1505) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
 
 #endif // _MESSAGE_H

--- a/include/swx/message.h
+++ b/include/swx/message.h
@@ -19,16 +19,16 @@
 #define _MESSAGE_H
 
 #define READ_ONLY_ADDRESS_BOUNDARY (0x20)
-#define MAX_STATE_MEM_SIZE (0x350)
+#define MAX_STATE_MEM_SIZE (0x450)
 
 #define REG_VERSION (0)                 // bytes 0 & 1 (readonly)
 #define REG_VERSION_L (REG_VERSION)     // (readonly)
 #define REG_VERSION_H (REG_VERSION + 1) // (readonly)
 
-#define REG_CHANNEL_COUNT (2)           // Number of channels (readonly)
-#define REG_CH_CAL_ENABLED (3)          // (readonly)
+#define REG_CHANNEL_COUNT (2)  // Number of channels (readonly)
+#define REG_CH_CAL_ENABLED (3) // (readonly)
 
-#define REG_CHn_STATUS (5)              // channel_status_t (readonly)
+#define REG_CHn_STATUS (5) // channel_status_t (readonly)
 #define REG_CH1_STATUS (REG_CHn_STATUS + 0)
 #define REG_CH2_STATUS (REG_CHn_STATUS + 1)
 #define REG_CH3_STATUS (REG_CHn_STATUS + 2)
@@ -42,7 +42,7 @@
 
 // -----------------------------------------------------
 
-#define REG_PSU_ENABLE (32)    // Enable/disable PSU
+#define REG_PSU_ENABLE (32) // Enable/disable PSU
 
 #define REG_CH_GEN_ENABLE (33) // Channel pulse_gen enabled
 #define REG_CH1_GEN_ENABLE_BIT (0)
@@ -93,6 +93,13 @@
 // TODO: Audio input Read
 // TODO: Fetch cal value (points)
 
-#define REG_CHnn_PARAM (128) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
+#define MAX_SEQ_COUNT (128)
 
-#endif                       // _MESSAGE_H
+#define REG_SEQ_PERIOD (90) // milliseconds (uint16_t)
+#define REG_SEQ_INDEX (92)
+#define REG_SEQ_COUNT (93) // sequence item count (uint8_t)
+#define REG_SEQn (94)      // max MAX_SEQ_COUNT
+
+#define REG_CHnn_PARAM (224) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
+
+#endif // _MESSAGE_H

--- a/include/swx/message.h
+++ b/include/swx/message.h
@@ -38,7 +38,7 @@
 #define REG_CH3_CAL_VALUE_w (REG_CHn_CAL_VALUE_w + 4)
 #define REG_CH4_CAL_VALUE_w (REG_CHn_CAL_VALUE_w + 6)
 
-// -----------------------------------------------------
+// ------------------------ READONLY BOUNDARY END ----------------------------- 
 
 #define REG_PSU_ENABLE (32) // Enable/disable PSU
 
@@ -107,7 +107,14 @@
 #define REG_An_PARAM_TARGET (226) // action parameter+target (uint8_t) upper nibble is parameter, lower nibble is target
 #define REG_An_VALUE_w (227)      // action value (uint16_t)
 
+#define MAX_TRIGS (32)
+#define TRIG_SIZE (4) // size of trig entry in bytes
 
-#define REG_CHn_PARAM_w (1505) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
+// Trig entries are stored sequentially and can be accessed using TRIG_SIZE * index + REG_TRIGn_...
+#define REG_TRIGn_INPUT (1505)    // uint8_t, upper nibble: trigger_mask, lower nibble: trigger_invert_mask
+#define REG_TRIGn_OUTPUT (1506)   // uint8_t, upper nibble: trigger_op_t, lower nibble: output_invert (bool)
+#define REG_TRIGn_ACTION_w (1507) // uint16_t, upper byte: action_start_index, lower byte: action_end_index
+
+#define REG_CHn_PARAM_w (1637) // Channel pulse generation parameters. see PARAM_TARGET_INDEX() for required offsets
 
 #endif // _MESSAGE_H

--- a/include/swx/parameter.h
+++ b/include/swx/parameter.h
@@ -103,13 +103,29 @@ typedef enum {
 
 typedef enum {
    ACTION_NONE = 0,
+
+   /// Set a parameter target value.
    ACTION_SET,
+
+   /// Increment a parameter target value. Action value is the amount to increment by.
    ACTION_INCREMENT,
+
+   /// Decrement a parameter target value. Action value is the amount to decrement by.
    ACTION_DECREMENT,
+
+   /// Enable pulse generation on one or more channels. If value is above zero, delay in milliseconds before disabling generation.
    ACTION_ENABLE,
+
+   /// Disable pulse generation on one or more channels. If value is above zero, delay in milliseconds before enabling generation.
    ACTION_DISABLE,
+
+   /// Toggle pulse generation on one or more channels. If value is above zero, delay in milliseconds before toggling generation again.
    ACTION_TOGGLE,
+
+   /// Run another action list. Value contains index range for list. Upper byte is start index, lower byte is end index.
    ACTION_EXECUTE,
+
+   /// Update a parameter for one or more channels.
    ACTION_PARAM_UPDATE,
 } action_type_t;
 

--- a/include/swx/parameter.h
+++ b/include/swx/parameter.h
@@ -68,6 +68,10 @@ typedef enum {
    /// The cycling mode the parameter is using. Determines how the value resets when it reaches min/max.
    TARGET_MODE,
 
+   /// Execute actions between start/end indices when value reaches min/max. Lower byte contains end index, upper byte contains start index.
+   /// Disable by setting upper and lower bytes equal
+   TARGET_ACTION_RANGE,
+
    TOTAL_TARGETS // Number of targets in enum, used for arrays
 
 } target_t;
@@ -97,6 +101,18 @@ typedef enum {
 
 } target_mode_t;
 
+typedef enum {
+   ACTION_NONE = 0,
+   ACTION_SET,
+   ACTION_INCREMENT,
+   ACTION_DECREMENT,
+   ACTION_ENABLE,
+   ACTION_DISABLE,
+   ACTION_TOGGLE,
+   ACTION_EXECUTE,
+   ACTION_PARAM_UPDATE,
+} action_type_t;
+
 #define PARAM_TARGET_INDEX_OFFSET(param, target) ((((param)*2) * TOTAL_TARGETS) + ((target)*2))
 #define PARAM_TARGET_INDEX_TOTAL (PARAM_TARGET_INDEX_OFFSET(TOTAL_PARAMS - 1, TOTAL_TARGETS - 1))
 
@@ -105,6 +121,6 @@ typedef enum {
 #define PARAM_TARGET_INDEX(ch_index, param, target) (((ch_index)*PARAM_TARGET_INDEX_TOTAL) + PARAM_TARGET_INDEX_OFFSET(param, target) + ((ch_index)*2))
 
 // Array size in bytes for all parameter target indices
-#define PARAM_TARGET_INDEX_MAX(channel_count) (PARAM_TARGET_INDEX((channel_count) - 1, TOTAL_PARAMS - 1, TOTAL_TARGETS - 1) + 2)
+#define PARAM_TARGET_INDEX_MAX(channel_count) (PARAM_TARGET_INDEX((channel_count)-1, TOTAL_PARAMS - 1, TOTAL_TARGETS - 1) + 2)
 
 #endif // _PARAMETER_H

--- a/include/swx/parameter.h
+++ b/include/swx/parameter.h
@@ -129,6 +129,18 @@ typedef enum {
    ACTION_PARAM_UPDATE,
 } action_type_t;
 
+typedef enum {
+   TRIGGER_OP_DDD = 0, // disabled
+   TRIGGER_OP_OOO, // t1 || t2 || t3 || t4
+   TRIGGER_OP_OOA, // t1 || t2 || t3 && t4
+   TRIGGER_OP_OAO, // t1 || t2 && t3 || t4
+   TRIGGER_OP_OAA, // t1 || t2 && t3 && t4
+   TRIGGER_OP_AOO, // t1 && t2 || t3 || t4
+   TRIGGER_OP_AOA, // t1 && t2 || t3 && t4
+   TRIGGER_OP_AAO, // t1 && t2 && t3 || t4
+   TRIGGER_OP_AAA, // t1 && t2 && t3 && t4
+} trigger_op_t;
+
 #define PARAM_TARGET_INDEX_OFFSET(param, target) ((((param)*2) * TOTAL_TARGETS) + ((target)*2))
 #define PARAM_TARGET_INDEX_TOTAL (PARAM_TARGET_INDEX_OFFSET(TOTAL_PARAMS - 1, TOTAL_TARGETS - 1))
 

--- a/src/main.c
+++ b/src/main.c
@@ -49,8 +49,9 @@ static void init() {
    stdio_init_all();                                    // needs to be called after setting clock
 
    LOG_INFO("~~ swx driver %u ~~\nStarting up...\n", SWX_VERSION);
-   if (clk_success)
+   if (clk_success) {
       LOG_DEBUG("sys_clk set to 250MHz\n");
+   }
 
    // Setup I2C as slave for comms with control device.
    protocol_init();

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,7 @@
 #include "protocol.h"
 #include "analog_capture.h"
 #include "pulse_gen.h"
+#include "trigger.h"
 
 #include "util/i2c.h"
 #include "util/gpio.h"
@@ -93,6 +94,8 @@ int main() {
    multicore_launch_core1(core1_entry);
 
    pulse_gen_init();
+   
+   triggers_init();
 
    LOG_DEBUG("Starting core0 loop...\n");
 
@@ -105,6 +108,7 @@ int main() {
 
       pulse_gen_process();
       output_process_pulses();
+      triggers_process();
    }
 
    // Code execution shouldn't get this far...

--- a/src/output.c
+++ b/src/output.c
@@ -218,7 +218,7 @@ bool output_calibrate_all() {
       }
 
       const uint16_t ch_status = REG_CHn_STATUS + ch_index;
-      const uint16_t ch_cal_value = REG_CHnn_CAL_VALUE + (ch_index * 2);
+      const uint16_t ch_cal_value = REG_CHn_CAL_VALUE_w + (ch_index * 2);
 
       if (get_state(ch_status) == CHANNEL_INVALID) { // This should not happen...
          success = false;
@@ -358,7 +358,7 @@ void output_process_power() {
       if (cmd.power > CHANNEL_POWER_MAX)
          cmd.power = CHANNEL_POWER_MAX;
 
-      const uint16_t cal_value = get_state16(REG_CHnn_CAL_VALUE + (cmd.channel * 2));
+      const uint16_t cal_value = get_state16(REG_CHn_CAL_VALUE_w + (cmd.channel * 2));
       int16_t dacValue = (cal_value + ch->cal_offset) - (cmd.power * 2);
 
       if (dacValue < 0 || dacValue > DAC_MAX_VALUE) {

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -23,12 +23,12 @@
 
 #include <pico/i2c_slave.h>
 
-uint8_t mem[MAX_STATE_MEM_SIZE];
-static volatile bool dirty = false;
+uint8_t mem[MAX_STATE_MEM_SIZE];    // I2C master accessible state memory
+static volatile bool dirty = false; // set true when I2C master sent a STOP or RESTART, set false when processed.
 
 static struct {
-   uint16_t address;
-   uint8_t ready;
+   uint16_t address; // the current memory address I2C is writing/reading at.
+   uint8_t ready;    // determines what part of the address is being written. 0: lower byte, 1: upper byte, 2: ready
 } ctx;
 
 #define CHECK_BOUNDS(n)                                                                                                                                                  \
@@ -96,9 +96,8 @@ void protocol_init() {
    i2c_slave_init(I2C_PORT_COMMS, I2C_ADDRESS_COMMS, i2c_slave_handler);
 }
 
-
 void protocol_process() {
-   if (!dirty) // master has signalled Stop / Restart
+   if (!dirty)
       return;
    dirty = false;
 
@@ -108,10 +107,10 @@ void protocol_process() {
    // run requested cmd
    const uint8_t state = get_state(REG_CMD);
    if (state) {
-      set_state(REG_CMD, 0);
-
       const uint8_t ch_index = (state & REG_CMD_CH_MASK) >> REG_CMD_CH_BIT;
       const uint16_t arg0 = get_state16(REG_CMD + 1);
+
+      set_state(REG_CMD, 0); // clear CMD, so I2C master can set another
 
       switch ((state & REG_CMD_ACTION_MASK) >> REG_CMD_ACTION_BIT) {
          case CMD_PULSE:

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -85,7 +85,7 @@ void protocol_init() {
    memset(mem, 0, MAX_STATE_MEM_SIZE);
 
    // set readonly info
-   set_state16(REG_VERSION, SWX_VERSION);
+   set_state16(REG_VERSION_w, SWX_VERSION);
    set_state(REG_CHANNEL_COUNT, CHANNEL_COUNT);
    set_state(REG_CH_CAL_ENABLED, CH_CAL_ENABLED);
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -21,8 +21,10 @@
 #include "swx.h"
 #include "message.h"
 
+// Init I2C hardware, I2C slave, and set register defaults.
 void protocol_init();
 
+// Process any commands (REG_CMD) and synchronize hardware states. 
 void protocol_process();
 
 #endif // _PROTOCOL_H

--- a/src/pulse_gen.c
+++ b/src/pulse_gen.c
@@ -253,7 +253,7 @@ static inline void execute_action(uint8_t a_index) {
       case ACTION_EXECUTE:                              // run another action list from this list
          execute_action_list(value >> 8, value & 0xff); // start:upper byte, end: lower byte
          break;
-      case ACTION_PARAM_UPDATE: // update parameter step/rate using channel mask
+      case ACTION_PARAM_UPDATE: { // update parameter step/rate using channel mask
          const uint8_t param_target = get_state(REG_An_PARAM_TARGET + a_index);
          const param_t param = param_target >> 8;
          for (uint8_t ch_index = 0; ch_index < CHANNEL_COUNT; ch_index++) {
@@ -261,6 +261,7 @@ static inline void execute_action(uint8_t a_index) {
                parameter_update(ch_index, param);
          }
          break;
+      }
       default:
          break;
    }

--- a/src/pulse_gen.c
+++ b/src/pulse_gen.c
@@ -24,6 +24,7 @@
 
 #define STATE_COUNT (4)
 
+// pulse generation power fade-in/fade-out transition sequence
 static const param_t STATE_SEQUENCE[STATE_COUNT] = {
     PARAM_ON_RAMP_TIME,
     PARAM_ON_TIME,
@@ -33,7 +34,7 @@ static const param_t STATE_SEQUENCE[STATE_COUNT] = {
 
 static channel_data_t channels[CHANNEL_COUNT];
 
-static uint32_t sequencer_time_us;
+static uint32_t sequencer_time_us; // next sequencer state change time in microseconds
 
 extern void audio_process(channel_data_t* ch, uint8_t ch_index, uint16_t power);
 
@@ -211,6 +212,7 @@ static int64_t ch_gen_mask_toggle_cb(alarm_id_t id, void* user_data) {
 
 static inline void execute_action_list(uint8_t al_start, uint8_t al_end);
 
+// execute the action at the given action slot index
 static inline void execute_action(uint8_t a_index) {
    if (a_index >= MAX_ACTIONS)
       return;
@@ -244,7 +246,7 @@ static inline void execute_action(uint8_t a_index) {
                val = GET_VALUE(ch_index, param, target) - value;
             }
 
-            if (target == TARGET_VALUE) {
+            if (target == TARGET_VALUE) { // limit target value between TARGET_MIN and TARGET_MAX
                const uint16_t min = GET_VALUE(ch_index, param, TARGET_MIN);
                const uint16_t max = GET_VALUE(ch_index, param, TARGET_MAX);
 
@@ -291,11 +293,14 @@ static inline void execute_action(uint8_t a_index) {
    }
 }
 
+// execute each action between indices al_start and al_end
 static inline void execute_action_list(uint8_t al_start, uint8_t al_end) {
    for (uint8_t i = al_start; i < al_end; i++)
       execute_action(i);
 }
 
+// Update the parameter value by stepping based on the current parameter mode and step rate.
+// Handles condition/actions when parameter reaches extent based on mode.
 static inline void parameter_step(uint8_t ch_index, param_t param) {
    parameter_data_t* p = &channels[ch_index].parameters[param];
 

--- a/src/pulse_gen.c
+++ b/src/pulse_gen.c
@@ -191,6 +191,7 @@ void pulse_gen_process() {
 
 // alarm callback function for disabling channel pulse generation using a channel mask
 static int64_t ch_gen_mask_disable_cb(alarm_id_t id, void* user_data) {
+   (void) id;
    const uint8_t channel_mask = (int)user_data;
    set_state(REG_CH_GEN_ENABLE, get_state(REG_CH_GEN_ENABLE) & ~channel_mask);
    return 0; // dont reschedule the alarm
@@ -198,6 +199,7 @@ static int64_t ch_gen_mask_disable_cb(alarm_id_t id, void* user_data) {
 
 // alarm callback function for enabling channel pulse generation using a channel mask
 static int64_t ch_gen_mask_enable_cb(alarm_id_t id, void* user_data) {
+   (void) id;   
    const uint8_t channel_mask = (int)user_data;
    set_state(REG_CH_GEN_ENABLE, get_state(REG_CH_GEN_ENABLE) | channel_mask);
    return 0; // dont reschedule the alarm
@@ -205,12 +207,11 @@ static int64_t ch_gen_mask_enable_cb(alarm_id_t id, void* user_data) {
 
 // alarm callback function for toggling channel pulse generation using a channel mask
 static int64_t ch_gen_mask_toggle_cb(alarm_id_t id, void* user_data) {
+   (void) id;
    const uint8_t channel_mask = (int)user_data;
    set_state(REG_CH_GEN_ENABLE, get_state(REG_CH_GEN_ENABLE) ^ channel_mask);
    return 0; // dont reschedule the alarm
 }
-
-static inline void execute_action_list(uint8_t al_start, uint8_t al_end);
 
 // execute the action at the given action slot index
 static inline void execute_action(uint8_t a_index) {
@@ -295,8 +296,7 @@ static inline void execute_action(uint8_t a_index) {
    }
 }
 
-// execute each action between indices al_start and al_end
-static inline void execute_action_list(uint8_t al_start, uint8_t al_end) {
+void execute_action_list(uint8_t al_start, uint8_t al_end) {
    for (uint8_t i = al_start; i < al_end; i++)
       execute_action(i);
 }

--- a/src/pulse_gen.h
+++ b/src/pulse_gen.h
@@ -22,18 +22,21 @@
 #include "parameter.h"
 #include "state.h"
 
+// Returns the uint16 parameter+target value for the given channel. See param_t and target_t.
 #define GET_VALUE(ch_index, param, target) get_state16(REG_CHnn_PARAM + PARAM_TARGET_INDEX((ch_index), (param), (target)))
+
+// Sets the uint16 parameter target value for the given channel. See param_t and target_t.
 #define SET_VALUE(ch_index, param, target, value) set_state16(REG_CHnn_PARAM + PARAM_TARGET_INDEX((ch_index), (param), (target)), (value))
 
 typedef struct {
-   int8_t step;
+   int8_t step; // number of steps to increment/decrement per parameter update
 
-   uint32_t next_update_time_us;
-   uint32_t update_period_us;
+   uint32_t next_update_time_us; // the next parameter step time in microseconds
+   uint32_t update_period_us;    // parameter step update period in microseconds
 } parameter_data_t;
 
 typedef struct {
-   uint8_t state_index;         // The current "waveform" state (e.g. off, on_ramp, on)
+   uint8_t state_index; // The current "waveform" state (e.g. off, on_ramp, on)
 
    uint32_t last_power_time_us; // The absolute timestamp since the last power update occurred
    uint32_t last_pulse_time_us; // The absolute timestamp since the last pulse occurred
@@ -46,8 +49,13 @@ typedef struct {
 
 void pulse_gen_init();
 
+// Update pulse generator by updating sequencer, parameters, power level transitions, and generating the actual
+// pulses manually or via audio processing depending on configured source.
 void pulse_gen_process();
 
+// Updates the parameter step period and step size based on the current target mode, minmum, maximum, and rate.
+// Should be called whenever TARGET_MODE, TARGET_MIN, TARGET_MAX, or TARGET_RATE is changed, and the parameter is
+// sweeping the value.
 void parameter_update(uint8_t ch_index, param_t param);
 
 #endif // _PULSE_GEN_H

--- a/src/pulse_gen.h
+++ b/src/pulse_gen.h
@@ -58,4 +58,7 @@ void pulse_gen_process();
 // sweeping the value.
 void parameter_update(uint8_t ch_index, param_t param);
 
+// execute each action between indices al_start and al_end
+void execute_action_list(uint8_t al_start, uint8_t al_end);
+
 #endif // _PULSE_GEN_H

--- a/src/pulse_gen.h
+++ b/src/pulse_gen.h
@@ -23,10 +23,10 @@
 #include "state.h"
 
 // Returns the uint16 parameter+target value for the given channel. See param_t and target_t.
-#define GET_VALUE(ch_index, param, target) get_state16(REG_CHnn_PARAM + PARAM_TARGET_INDEX((ch_index), (param), (target)))
+#define GET_VALUE(ch_index, param, target) get_state16(REG_CHn_PARAM_w + PARAM_TARGET_INDEX((ch_index), (param), (target)))
 
 // Sets the uint16 parameter target value for the given channel. See param_t and target_t.
-#define SET_VALUE(ch_index, param, target, value) set_state16(REG_CHnn_PARAM + PARAM_TARGET_INDEX((ch_index), (param), (target)), (value))
+#define SET_VALUE(ch_index, param, target, value) set_state16(REG_CHn_PARAM_w + PARAM_TARGET_INDEX((ch_index), (param), (target)), (value))
 
 typedef struct {
    int8_t step; // number of steps to increment/decrement per parameter update

--- a/src/state.h
+++ b/src/state.h
@@ -21,22 +21,30 @@
 #include "swx.h"
 #include "message.h"
 
+// Set an 8-bit I2C accessible value at the given address. Bypasses readonly region defined by READ_ONLY_ADDRESS_BOUNDARY.
+// Value is accessible by the I2C master.
 static inline void set_state(uint16_t address, uint8_t value) {
    extern uint8_t mem[MAX_STATE_MEM_SIZE];
-   mem[address] = value; 
+   mem[address] = value;
 }
 
+// Set a 16-bit I2C accessible value at the current and next address. Bypasses readonly region defined by READ_ONLY_ADDRESS_BOUNDARY.
+// Value is accessible by the I2C master.
+// address+0: lower byte
+// address+1: upper byte
 static inline void set_state16(uint16_t address, uint16_t value) {
    extern uint8_t mem[MAX_STATE_MEM_SIZE];
    mem[address] = value & 0xFF;
    mem[address + 1] = (value >> 8) & 0xFF;
 }
 
+// Returns the 8-bit I2C accessible value at the given address. Value is accessible by the I2C master.
 static inline uint8_t get_state(uint16_t address) {
    extern uint8_t mem[MAX_STATE_MEM_SIZE];
    return mem[address];
 }
 
+// Returns the 16-bit I2C accessible value by using the current and next address. Value is accessible by the I2C master.
 static inline uint16_t get_state16(uint16_t address) {
    extern uint8_t mem[MAX_STATE_MEM_SIZE];
    return mem[address] | (mem[address + 1] << 8);

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -1,0 +1,141 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "trigger.h"
+
+#include <hardware/gpio.h>
+
+#include "parameter.h"
+#include "message.h"
+#include "state.h"
+#include "pulse_gen.h"
+
+#if TRIGGER_COUNT > 0
+static volatile bool triggers_dirty = false;
+static uint32_t next_update_time_us = 0;
+
+static bool previous_results[MAX_TRIGS] = {0};
+
+void __not_in_flash_func(trigger_callback)(uint gpio, uint32_t events) {
+   triggers_dirty = true;
+}
+#endif
+
+void triggers_init() {
+#if TRIGGER_COUNT > 0
+   gpio_set_irq_enabled_with_callback(PIN_TRIGGER1, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &trigger_callback);
+#if TRIGGER_COUNT > 1
+   gpio_set_irq_enabled_with_callback(PIN_TRIGGER2, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &trigger_callback);
+#if TRIGGER_COUNT > 2
+   gpio_set_irq_enabled_with_callback(PIN_TRIGGER3, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &trigger_callback);
+#if TRIGGER_COUNT > 3
+   gpio_set_irq_enabled_with_callback(PIN_TRIGGER4, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &trigger_callback);
+#endif
+#endif
+#endif
+#endif
+}
+
+void triggers_process() {
+#if TRIGGER_COUNT > 0
+
+   // only process triggers when GPIO changes and no faster than 50 ms
+   if (!triggers_dirty || time_us_32() > next_update_time_us)
+      return;
+   next_update_time_us = time_us_32() + 50000ul; // every 50 ms
+
+   // get trigger IO state as bit field (LSB is trigger 1)
+   const uint8_t state = (gpio_get(PIN_TRIGGER1) << 0)
+#if TRIGGER_COUNT > 1
+                         | (gpio_get(PIN_TRIGGER2) << 1)
+#if TRIGGER_COUNT > 2
+                         | (gpio_get(PIN_TRIGGER3) << 2)
+#if TRIGGER_COUNT > 3
+                         | (gpio_get(PIN_TRIGGER4) << 3)
+#endif
+#endif
+#endif
+       ;
+
+   for (uint32_t trig_index = 0; trig_index < MAX_TRIGS; trig_index++) {
+      const uint8_t offset = TRIG_SIZE * trig_index;
+
+      const uint8_t input = get_state(offset + REG_TRIGn_INPUT);
+      const uint8_t trigger_mask = input >> 4;
+      const uint8_t trigger_invert_mask = input & 0xf;
+
+      if (!trigger_mask)
+         continue;
+
+      const uint8_t output = get_state(offset + REG_TRIGn_OUTPUT);
+      const trigger_op_t trigger_op = output >> 4;
+      const bool output_invert = !!(output & 0xf);
+
+      if (trigger_op == TRIGGER_OP_DDD)
+         continue;
+
+      const uint16_t action = get_state16(offset + REG_TRIGn_ACTION_w);
+      const uint8_t action_start = action >> 8;
+      const uint8_t action_end = action & 0xff;
+      if (!action || (action_start == action_end))
+         continue;
+
+      const uint8_t trig_state = (state & trigger_mask) ^ trigger_invert_mask;
+
+      bool result;
+      switch (trigger_op) {
+         case TRIGGER_OP_OOO: // t1 || t2 || t3 || t4
+            result = !!trig_state;
+            break;
+         case TRIGGER_OP_OOA: // t1 || t2 || t3 && t4
+            result = !!(trig_state & 0b0011) || ((trig_state & 0b1100) == 0b1100);
+            break;
+         case TRIGGER_OP_OAO: // t1 || t2 && t3 || t4
+            result = !!(trig_state & 0b1001) || ((trig_state & 0b0110) == 0b0110);
+            break;
+         case TRIGGER_OP_OAA: // t1 || t2 && t3 && t4
+            result = !!(trig_state & 0b0001) || ((trig_state & 0b1110) == 0b1110);
+            break;
+         case TRIGGER_OP_AOO: // t1 && t2 || t3 || t4
+            result = !!(trig_state & 0b1100) || ((trig_state & 0b0011) == 0b0011);
+            break;
+         case TRIGGER_OP_AOA: // t1 && t2 || t3 && t4
+            result = ((trig_state & 0b1100) == 0b1100) || ((trig_state & 0b0011) == 0b0011);
+            break;
+         case TRIGGER_OP_AAO: // t1 && t2 && t3 || t4
+            result = !!(trig_state & 0b1000) || ((trig_state & 0b0111) == 0b0111);
+            break;
+         case TRIGGER_OP_AAA: // t1 && t2 && t3 && t4
+            result = (trig_state == 0b1111);
+            break;
+         default:
+            continue;
+      }
+
+      result ^= output_invert;
+
+      // only trigger action if result is true and has changed since last time
+      if (result != previous_results[trig_index]) {
+         previous_results[trig_index] = result;
+         if (result)
+            execute_action_list(action_start, action_end);
+      }
+   }
+
+   triggers_dirty = false;
+#endif
+}

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -1,0 +1,27 @@
+/*
+ * swx
+ * Copyright (C) 2023 saawsm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _TRIGGER_H
+#define _TRIGGER_H
+
+#include "swx.h"
+
+void triggers_init();
+
+void triggers_process();
+
+#endif // _TRIGGER_H

--- a/src/util/i2c.c
+++ b/src/util/i2c.c
@@ -41,8 +41,9 @@ void i2c_scan(i2c_inst_t* i2c) { // TODO: Return found I2C device addresses
       if ((address & 0x78) == 0 || (address & 0x78) == 0x78) // I2C reserves some addresses for special purposes. These are 1111XXX and 0000XXX.
          continue;
 
-      if (i2c_read_blocking(i2c, address, &data, 1, false) > 0)
+      if (i2c_read_blocking(i2c, address, &data, 1, false) > 0) {
          LOG_DEBUG("Found device at 0x%02x\n", address);
+      }
    }
 
 #ifdef I2C_MUTEX_TIMEOUT


### PR DESCRIPTION
Allow swx to run without a host "script" (aka. routine) by adding the following:
- Channel sequencer (channels will be toggled in a host defined sequence)
- Triggers: Digital input triggers that can invoke a list of actions. Conditionals are host defined (e.g. `AND` or `OR`)
- Action lists (each action can set various parameters or do certain things, invoked from triggers or parameter extent reached)